### PR TITLE
Require only schedule name when asserting absence

### DIFF
--- a/Tests/xScheduledTaskDSC.tests.ps1
+++ b/Tests/xScheduledTaskDSC.tests.ps1
@@ -24,12 +24,6 @@ $badsplat = @{
 $removesplat  = @{
             "Ensure" = "Absent"
             "Name" = "xScheduledTaskDSC Pester Test ScheduledTask"
-            "Arguments" = " -noprofile -command `"Get-Website`""
-            "Execute" = "powershell.exe"
-            "At" = "9:30AM"
-            "Repeat" = "Custom"
-            "IntervalMinutes" = 20
-            "UserName" = "SYSTEM"
           } # standard splat for tests
 
 


### PR DESCRIPTION
When setting `Ensure` to "Absent", the only other parameter that we really need in order to carry out the assertion is `Name` . This change prevents validation errors from being thrown when the other parameters have not been specified.